### PR TITLE
The set/get command works properly

### DIFF
--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -429,9 +429,9 @@ max-rsync-parallel-num : 4
 cache-num : 16
 
 # cache-model 0:cache_none 1:cache_read
-cache-model : 0
+cache-model : 1
 # cache-type: string, set, zset, list, hash, bit
-cache-type: zset
+cache-type: string, set, zset, list, hash, bit
 # cache-start-direction 0:cache first ${cache-items-per-key} items; -1:cache last ${cache-items-per-key} items
 cache-start-direction : 0
 cache-items-per-key : 512

--- a/include/pika_command.h
+++ b/include/pika_command.h
@@ -231,7 +231,7 @@ enum CmdFlagsMask {
   kCmdFlagsMaskPrior = 128,
   kCmdFlagsMaskAdminRequire = 256,
   kCmdFlagsMaskCacheDo = 1024,
-  kCmdFlagsMaskPreDo = 2077,
+  kCmdFlagsMaskPreDo = 512,
   kCmdFlagsMaskUpdateCache = 2048,
   kCmdFlagsMaskOnlyDoCache = 4096,
   kCmdFlagsMaskSlot = 1536,
@@ -261,7 +261,7 @@ enum CmdFlags {
   kCmdFlagsDoNotSpecifySlot = 0,  // default do not specify slot
   kCmdFlagsSingleSlot = 512,
   kCmdFlagsMultiSlot = 1024,
-  kCmdFlagsPreDo = 2077,
+  kCmdFlagsPreDo = 512,
   kCmdFlagsUpdateCache = 2048,
   kCmdFlagsOnlyDoCache = 4096,
 };
@@ -462,6 +462,8 @@ class Cmd : public std::enable_shared_from_this<Cmd> {
   virtual void Do(std::shared_ptr<Slot> slot = nullptr) = 0;
   virtual void DoFromCache(std::shared_ptr<Slot> slot = nullptr) {}
   virtual void DoUpdateCache(std::shared_ptr<Slot> slot = nullptr) {}
+  virtual void PreDo(std::shared_ptr<Slot> slot = nullptr) {}
+  rocksdb::Status CmdStatus() { return s_; };
   virtual Cmd* Clone() = 0;
   // used for execute multikey command into different slots
   virtual void Split(std::shared_ptr<Slot> slot, const HintKeys& hint_keys) = 0;
@@ -521,6 +523,7 @@ class Cmd : public std::enable_shared_from_this<Cmd> {
   CmdRes res_;
   PikaCmdArgsType argv_;
   std::string db_name_;
+  rocksdb::Status s_;
 
   std::weak_ptr<net::NetConn> conn_;
   std::weak_ptr<std::string> resp_;

--- a/include/pika_kv.h
+++ b/include/pika_kv.h
@@ -58,7 +58,7 @@ class GetCmd : public Cmd {
   void Do(std::shared_ptr<Slot> slot = nullptr) override;
   void DoFromCache(std::shared_ptr<Slot> slot = nullptr) override;
   void DoUpdateCache(std::shared_ptr<Slot> slot = nullptr) override;
-  //void PreDo(std::shared_ptr<Slot> slot = nullptr);
+  void PreDo(std::shared_ptr<Slot> slot = nullptr) override;
   void Split(std::shared_ptr<Slot> slot, const HintKeys& hint_keys) override{};
   void Merge() override{};
   Cmd* Clone() override { return new GetCmd(*this); }

--- a/src/pika_cache.cc
+++ b/src/pika_cache.cc
@@ -60,7 +60,10 @@ void PikaCache::Destroy(void) {
 
 void PikaCache::SetCacheStatus(int status) { cache_status_ = status; }
 
-int PikaCache::CacheStatus(void) { return cache_status_; }
+int PikaCache::CacheStatus(void) {
+  LOG(INFO) << "er";
+  return cache_status_;
+}
 
 /*-----------------------------------------------------------------------------
  * Normal Commands

--- a/src/pika_cache_manager.cc
+++ b/src/pika_cache_manager.cc
@@ -29,7 +29,7 @@ void PikaCacheManager::ProcessCronTask() {
   for (auto& cache : caches_) {
     cache.second->ActiveExpireCycle();
   }
-  LOG(INFO) << "hit rate:" << HitRatio() << std::endl;
+  //LOG(INFO) << "hit rate:" << HitRatio() << std::endl;
 }
 
 double PikaCacheManager::HitRatio(void) {

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -831,20 +831,20 @@ void Cmd::DoCommand(const std::shared_ptr<Slot>& slot, const HintKeys& hint_keys
     slot->DbRWLockReader();
   }
   if (need_cache_do()
-      && PIKA_CACHE_NONE != g_pika_conf->cache_model()
-      && PIKA_CACHE_STATUS_OK == g_pika_server->Cache()->CacheStatus()) {
+      && PIKA_CACHE_NONE != g_pika_conf->cache_model()) {
+     // && PIKA_CACHE_STATUS_OK == g_pika_server->Cache()->CacheStatus()) {
 
     if (is_need_read_cache()) {
-      DoFromCache(slot);
+      PreDo(slot);
     }
-    if (is_read()) {
-      Do(slot);
-      if (is_need_update_cache()) {
+    if (is_read() && res().CacheMiss()) {
+      DoFromCache(slot);
+      if (CmdStatus().ok() && is_need_update_cache()) {
         DoUpdateCache(slot);
       }
     } else if (is_write()) {
-      Do(slot);
-      if (is_need_update_cache()) {
+      DoFromCache(slot);
+      if (CmdStatus().ok() && is_need_update_cache()) {
         DoUpdateCache(slot);
       }
     }


### PR DESCRIPTION
# 背景

以 Pika 的单机模式走通了 String 类型下的 set/get 命令

# 流程

```cpp
void Cmd::DoCommand(const std::shared_ptr<Slot>& slot, const HintKeys& hint_keys) {
  if (!is_suspend()) {
    slot->DbRWLockReader();
  }
  if (need_cache_do() // 判断该命令需要操作缓存
      && PIKA_CACHE_NONE != g_pika_conf->cache_model()) { // 判断缓存模式不为NONE
      && PIKA_CACHE_STATUS_OK == g_pika_server->Cache()->CacheStatus()) { // 判断缓存状态为OK

    if (is_need_read_cache()) { // 如果是读命令，执行读缓存
      PreDo(slot); // 读缓存
    }
    if (is_read() && res().CacheMiss()) { // 如果是读命令，并且缓存未命中，执行读DB
      DoFromCache(slot); // 读RocksDB操作
      if (CmdStatus().ok() && is_need_update_cache()) { // 如果读RocksDB成功并且是需要更新缓存
        DoUpdateCache(slot); // 更新缓存
      }
    } else if (is_write()) { // 如果是写命令
      DoFromCache(slot); // 写RocksDB
      if (CmdStatus().ok() && is_need_update_cache()) { // 如果写RocksDB成功并且需要更新缓存
        DoUpdateCache(slot); // 更新缓存
      }
    }
  } else {
    Do(slot); // 普通的Do流程
  }
  if (!is_suspend()) {
    slot->DbRWUnLock();
  }
}
```

##### 以 Set 命令为例子，我们看下它的几种命令操作

`DoFromCache`:  写 RocksDB，调用 Do 接口

```cpp
void SetCmd::DoFromCache(std::shared_ptr<Slot> slot) {
  Do(slot);
}
```

`UpdateCache`：更新缓存

```cpp
void SetCmd::DoUpdateCache(std::shared_ptr<Slot> slot) {
  switch (condition_) {
    case SetCmd::kXX:
      slot->cache()->Setxx(key_, value_, sec_);
      break;
    case SetCmd::kNX:
      slot->cache()->Setnx(key_, value_, sec_);
      break;
    case SetCmd::kVX:
      slot->cache()->Setvx(key_, target_, value_, sec_);
      break;
    case SetCmd::kEXORPX:
      slot->cache()->Setex(key_, value_, static_cast<int32_t>(sec_));
      break;
    default:
      slot->cache()->SetWithoutTTL(key_, value_);
      break;
  }
}
```

`PreDo`：由于 Set 是写操作，所以没有 `PreDo`读缓存命令



##### 以 Get 命令为例子，我们看下它的几种命令操作

`DoFromCache`: 写 RocksDB，调用 Do 接口

```cpp
void GetCmd::DoFromCache(std::shared_ptr<Slot> slot) {
  res_.clear();
  s_ = slot->db()->GetWithTTL(key_, &value_,&sec_);
  if (s_.ok()) {
    res_.AppendStringLenUint64(value_.size());
    res_.AppendContent(value_);
  } else if (s_.IsNotFound()) {
    res_.AppendStringLen(-1);
  } else {
    res_.SetRes(CmdRes::kErrOther, s_.ToString());
  }
}
```

`UpdateCache`：更新缓存

```cpp
void GetCmd::DoUpdateCache(std::shared_ptr<Slot> slot) {
  if (s_.ok()) { // 如果写RocksDB成功执行更新缓存
    slot->cache()->Set(key_, value_, sec_);
  }
}
```

`PreDo`: 读缓存操作

```cpp
void GetCmd::PreDo(std::shared_ptr<Slot> slot) {
  auto s = slot->cache()->Get(key_, &value_);
  if (s.ok()) {
    res_.AppendStringLen(value_.size());
    res_.AppendContent(value_);
  } else {
    res_.SetRes(CmdRes::kCacheMiss);
  }
}
```



# 总结

一共有 4 种执行命令：

`Do`: Pika 原生的执行命令方法

`PreDo`：读缓存操作

`UpdateCache`: 更新缓存操作

`DoFromCache` : 写命令下默认调用的就是 `Do` 接口，读命令下会先调用 `res_.clear()`清空之前 `PreDo`的 `res_`结果，然后调用 `Do`

写命令：

```cpp
void SetCmd::CacheDo() {
	Do();
}
```

读命令：

```cpp
void ExistsCmd::CacheDo() {
	res_.clear();
	Do();
}
```



对于 `DoFromCache`命令，我们也发现了有一些读命令不单单是调用的 `Do`接口，而是选择了直接重写

```cpp
void StrlenCmd::Do() {
	int32_t len = 0;
	s_ = g_pika_server->db()->Strlen(key_, &len);
	if (s_.ok() || s_.IsNotFound()) {
		res_.AppendInteger(len);
	} else {
		res_.SetRes(CmdRes::kErrOther, s_.ToString());
	}
	return;
}
```

```cpp
void StrlenCmd::CacheDo() {
	res_.clear();
	s_ = g_pika_server->db()->GetWithTTL(key_, &value_, &sec_);
	if (s_.ok() || s_.IsNotFound()) {
		res_.AppendInteger(value_.size());
	} else {
		res_.SetRes(CmdRes::kErrOther, s_.ToString());
	}
}
```

比如这里的 `strlen`命令，原生的 `Do` 命令是直接调 `strlen`接口，其实底层还是调 `Get` 接口先获取到 Key 然后计算 Key 的 size, 而 `CacheDo` 这边的话直接就是调用的 `Get`接口了，然后计算出 value 的 size



# 问题

1. 下面注释的代码中： 这里是否需要对key进行加锁，保证操作 rocksdb 和 cache 是原子的

```cpp
void Cmd::DoCommand(const std::shared_ptr<Slot>& slot, const HintKeys& hint_keys) {
  if (!is_suspend()) {
    slot->DbRWLockReader();
  }
  if (need_cache_do()
      && PIKA_CACHE_NONE != g_pika_conf->cache_model()) {
      && PIKA_CACHE_STATUS_OK == g_pika_server->Cache()->CacheStatus()) {

    if (is_need_read_cache()) {
      PreDo(slot);
    }
    if (is_read() && res().CacheMiss()) {
      // slash::ScopeRecordLock l(g_pika_server->LockMgr(), argv[1]); 
      DoFromCache(slot);
      if (CmdStatus().ok() && is_need_update_cache()) {
        DoUpdateCache(slot);
      }
    } else if (is_write()) {
      DoFromCache(slot);
      if (CmdStatus().ok() && is_need_update_cache()) {
        DoUpdateCache(slot);
      }
    }
  } else {
    Do(slot);
  }
  if (!is_suspend()) {
    slot->DbRWUnLock();
  }
}
```

2. 既然 `CacheDo`调用的接口的就是 `Do` ,只是部分场景下会需要把 `res_`清空，那么我们可不可以直接在每个 `Do` 接口执行之前调用 `res_.clear` 这样就不需要再去给每个命令写 `CacheDo`方法了

3. 代码中有逻辑冗余的地方

   ```cpp
   void Cmd::DoCommand(const std::shared_ptr<Slot>& slot, const HintKeys& hint_keys) {
     if (!is_suspend()) {
       slot->DbRWLockReader();
     }
     if (need_cache_do()
         && PIKA_CACHE_NONE != g_pika_conf->cache_model()) {
         && PIKA_CACHE_STATUS_OK == g_pika_server->Cache()->CacheStatus()) {

       if (is_need_read_cache()) {
         PreDo(slot);
       }
       if (is_read() && res().CacheMiss()) {
         DoFromCache(slot);
         if (CmdStatus().ok() && is_need_update_cache()) { // 这里的CmdStatus().ok() 返回是s_的值，代表写DB是否成功
           DoUpdateCache(slot);
         }
       } else if (is_write()) {
         DoFromCache(slot);
         if (CmdStatus().ok() && is_need_update_cache()) {
           DoUpdateCache(slot);
         }
       }
     } else {
       Do(slot);
     }
     if (!is_suspend()) {
       slot->DbRWUnLock();
     }
   }
   ```

   ```cpp
   void GetCmd::DoUpdateCache(std::shared_ptr<Slot> slot) {
     if (s_.ok()) { // 这里又重新判断了一次s_的返回值
       slot->cache()->Set(key_, value_, sec_);
     }
   }
   ```

   ​